### PR TITLE
fix procedure syntax

### DIFF
--- a/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
+++ b/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
@@ -23,7 +23,7 @@ object Concurrent {
 
     val p = Promise[A]()
     timer.schedule(new java.util.TimerTask {
-      def run() {
+      def run(): Unit = {
         p.success(v)
       }
     }, unit.toMillis(delay))
@@ -40,14 +40,14 @@ object Concurrent {
      *
      * @param chunk The chunk to push
      */
-    def push(chunk: Input[E])
+    def push(chunk: Input[E]): Unit
 
     /**
      * Push an item into this channel
      *
      * @param item The item to push
      */
-    def push(item: E) { push(Input.El(item)) }
+    def push(item: E): Unit = { push(Input.El(item)) }
 
     /**
      * Send a failure to this channel.  This results in any promises that the enumerator associated with this channel
@@ -60,7 +60,7 @@ object Concurrent {
      *
      * @param e The failure.
      */
-    def end(e: Throwable)
+    def end(e: Throwable): Unit
 
     /**
      * End the input for this channel.  This results in any promises that the enumerator associated with this channel
@@ -74,12 +74,12 @@ object Concurrent {
      * invocation, that is, subsequent calls to end will change the behaviour of attaching new iteratees to the
      * broadcast enumerator.
      */
-    def end()
+    def end(): Unit
 
     /**
      * Send an EOF to the channel, and then end the input for the channel.
      */
-    def eofAndEnd() {
+    def eofAndEnd(): Unit = {
       push(Input.EOF)
       end()
     }
@@ -546,7 +546,7 @@ object Concurrent {
     /**
      * Close the broadcasting enumerator.
      */
-    def close()
+    def close(): Unit
 
     /**
      * Whether this broadcaster is closed.
@@ -630,7 +630,7 @@ object Concurrent {
 
       def noCords() = iteratees.single().isEmpty
 
-      def close() {
+      def close(): Unit = {
         closeFlag = true
       }
 

--- a/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -224,7 +224,7 @@ object Enumerator {
       val attending: Ref[Option[Seq[Boolean]]] = Ref(Some(es.map(_ => true)))
       val result = Promise[Iteratee[E, A]]()
 
-      def redeemResultIfNotYet(r: Iteratee[E, A]) {
+      def redeemResultIfNotYet(r: Iteratee[E, A]): Unit = {
         if (attending.single.transformIfDefined { case Some(_) => None })
           result.success(r)
       }
@@ -298,7 +298,7 @@ object Enumerator {
       val attending: Ref[Option[(Boolean, Boolean)]] = Ref(Some(true -> true))
       val result = Promise[Iteratee[E2, A]]()
 
-      def redeemResultIfNotYet(r: Iteratee[E2, A]) {
+      def redeemResultIfNotYet(r: Iteratee[E2, A]): Unit = {
         if (attending.single.transformIfDefined { case Some(_) => None })
           result.success(r)
       }
@@ -504,7 +504,7 @@ object Enumerator {
 
       val iterateeP = Promise[Iteratee[E, A]]()
 
-      def step(it: Iteratee[E, A], initial: Boolean = false) {
+      def step(it: Iteratee[E, A], initial: Boolean = false): Unit = {
 
         val next = it.fold {
           case Step.Cont(k) => {
@@ -612,17 +612,17 @@ object Enumerator {
   def outputStream(a: java.io.OutputStream => Unit)(implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
     Concurrent.unicast[Array[Byte]] { channel =>
       val outputStream = new java.io.OutputStream() {
-        override def close() {
+        override def close(): Unit = {
           channel.end()
         }
-        override def flush() {}
-        override def write(value: Int) {
+        override def flush(): Unit = {}
+        override def write(value: Int): Unit = {
           channel.push(Array(value.toByte))
         }
-        override def write(buffer: Array[Byte]) {
+        override def write(buffer: Array[Byte]): Unit = {
           write(buffer, 0, buffer.length)
         }
-        override def write(buffer: Array[Byte], start: Int, count: Int) {
+        override def write(buffer: Array[Byte], start: Int, count: Int): Unit = {
           channel.push(buffer.slice(start, start + count))
         }
       }

--- a/iteratees/src/test/scala/play/api/libs/iteratee/ExecutionSpec.scala
+++ b/iteratees/src/test/scala/play/api/libs/iteratee/ExecutionSpec.scala
@@ -23,7 +23,7 @@ object ExecutionSpec extends Specification {
     }
 
     "not overflow the stack" in {
-      def executeRecursively(ec: ExecutionContext, times: Int) {
+      def executeRecursively(ec: ExecutionContext, times: Int): Unit = {
         if (times > 0) {
           ec.execute(new Runnable {
             def run() = executeRecursively(ec, times - 1)

--- a/iteratees/src/test/scala/play/api/libs/iteratee/IterateeSpecification.scala
+++ b/iteratees/src/test/scala/play/api/libs/iteratee/IterateeSpecification.scala
@@ -69,7 +69,7 @@ trait IterateeSpecification {
   def timeout[A](a: => A, d: Duration)(implicit e: ExecutionContext): Future[A] = {
     val p = Promise[A]()
     timer.schedule(new java.util.TimerTask {
-      def run() {
+      def run(): Unit = {
         p.complete(Try(a))
       }
     }, d.toMillis)


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

fix procedure syntax

## Purpose

add explicit `: Unit = `

## Background Context

procedure syntax is deprecated 

## References

https://github.com/scala/scala/commit/1d4d901fcea0a162cd139836b246e85cc0130a6b
