### PR TITLE
Remove ExecutionContext prepare

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 sudo: false
 group: beta
 scala:
-- 2.12.1
-- 2.11.8
+- 2.12.6
+- 2.11.11
 jdk:
 - oraclejdk8
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 sudo: false
 group: beta
 scala:
-- 2.12.6
-- 2.11.11
+- 2.12.8
+- 2.11.12
 jdk:
 - oraclejdk8
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val `play-iteratees` = project
   .enablePlugins(PlayLibrary)
   .settings(formattingSettings)
   .settings(
-    scalaVersion := scala212,	
+    scalaVersion := scala212,
     crossScalaVersions := Seq(scala212, scala211),
     libraryDependencies ++= Seq(
       "org.scala-stm" %% "scala-stm" % "0.9"
@@ -38,7 +38,7 @@ lazy val `play-iteratees-reactive-streams` = project
   .enablePlugins(PlayLibrary)
   .settings(Defaults.itSettings, formattingSettings)
   .settings(
-    scalaVersion := scala212,   
+    scalaVersion := scala212, 
     crossScalaVersions := Seq(scala212, scala211),
     libraryDependencies ++= Seq(
       "org.reactivestreams" % "reactive-streams" % "1.0.2"
@@ -49,7 +49,7 @@ lazy val `play-iteratees-root` = (project in file("."))
   .enablePlugins(PlayRootProject)
   .aggregate(`play-iteratees`, `play-iteratees-reactive-streams`)
   .settings(
-    scalaVersion := scala212,	
-    crossScalaVersions := Seq(scala212, scala211)	
+    scalaVersion := scala212,
+    crossScalaVersions := Seq(scala212, scala211)
   )
 playBuildRepoName in ThisBuild := "play-iteratees"

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val `play-iteratees-reactive-streams` = project
   .enablePlugins(PlayLibrary)
   .settings(Defaults.itSettings, formattingSettings)
   .settings(
-    scalaVersion := scala212, 
+    scalaVersion := scala212,
     crossScalaVersions := Seq(scala212, scala211),
     libraryDependencies ++= Seq(
       "org.reactivestreams" % "reactive-streams" % "1.0.2"

--- a/build.sbt
+++ b/build.sbt
@@ -1,42 +1,42 @@
 import interplay.ScalaVersions._
 
-val specsVersion = "3.8.9"
+val scala213Version = "2.13.0-M5"
+
+val specsVersion = "4.3.6"
 val specsBuild = Seq(
   "specs2-core",
   "specs2-junit",
   "specs2-mock"
 ).map("org.specs2" %% _ % specsVersion)
 
+val commonSettings = scalariformSettings ++ Seq(
+  scalaVersion := scala212,
+  crossScalaVersions := Seq(scala212, scala211, scala213Version)
+)
+
 lazy val `play-iteratees` = project
   .in(file("iteratees"))
   .enablePlugins(PlayLibrary)
-  .settings(scalariformSettings: _*)
+  .settings(commonSettings: _*)
   .settings(
-    scalaVersion := scala212,
-    crossScalaVersions := Seq(scala212, scala211),
     libraryDependencies ++= Seq(
-      "org.scala-stm" %% "scala-stm" % "0.8"
+      "org.scala-stm" %% "scala-stm" % "0.9"
     ) ++ specsBuild.map(_ % Test)
   )
 
 lazy val `play-iteratees-reactive-streams` = project
   .in(file("streams"))
   .enablePlugins(PlayLibrary)
-  .settings(scalariformSettings: _*)
+  .settings(commonSettings: _*)
   .settings(
-    scalaVersion := scala212,
-    crossScalaVersions := Seq(scala212, scala211),
     libraryDependencies ++= Seq(
-      "org.reactivestreams" % "reactive-streams" % "1.0.0"
+      "org.reactivestreams" % "reactive-streams" % "1.0.2"
     ) ++ specsBuild.map(_ % Test)
   ).dependsOn(`play-iteratees`)
 
 lazy val `play-iteratees-root` = (project in file("."))
   .enablePlugins(PlayRootProject)
   .aggregate(`play-iteratees`, `play-iteratees-reactive-streams`)
-  .settings(
-    scalaVersion := scala212,
-    crossScalaVersions := Seq(scala212, scala211)
-  )
+  .settings(commonSettings: _*)
 
 playBuildRepoName in ThisBuild := "play-iteratees"

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import interplay.ScalaVersions._
 import scalariform.formatter.preferences._
 
-val scala213Version = "2.13.0-M5"
-
 val specsVersion = "4.3.6"
 val specsBuild = Seq(
   "specs2-core",

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,8 @@ lazy val `play-iteratees` = project
   .enablePlugins(PlayLibrary)
   .settings(formattingSettings)
   .settings(
+    scalaVersion := scala212,	
+    crossScalaVersions := Seq(scala212, scala211),
     libraryDependencies ++= Seq(
       "org.scala-stm" %% "scala-stm" % "0.9"
     ) ++ specsBuild.map(_ % Test)
@@ -36,6 +38,8 @@ lazy val `play-iteratees-reactive-streams` = project
   .enablePlugins(PlayLibrary)
   .settings(Defaults.itSettings, formattingSettings)
   .settings(
+    scalaVersion := scala212,   
+    crossScalaVersions := Seq(scala212, scala211),
     libraryDependencies ++= Seq(
       "org.reactivestreams" % "reactive-streams" % "1.0.2"
     ) ++ specsBuild.map(_ % Test)
@@ -44,6 +48,8 @@ lazy val `play-iteratees-reactive-streams` = project
 lazy val `play-iteratees-root` = (project in file("."))
   .enablePlugins(PlayRootProject)
   .aggregate(`play-iteratees`, `play-iteratees-reactive-streams`)
-  .settings(commonSettings: _*)
-
+  .settings(
+    scalaVersion := scala212,	
+    crossScalaVersions := Seq(scala212, scala211)	
+  )
 playBuildRepoName in ThisBuild := "play-iteratees"

--- a/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -529,9 +529,10 @@ object Enumerator {
             Future.successful(None)
         }(dec)
 
-        next.onFailure {
-          case reason: Exception =>
+        next.onComplete {
+          case Failure(reason) =>
             onError(reason.getMessage(), Input.Empty)
+          case _ =>
         }(dec)
 
         next.onComplete {

--- a/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -112,13 +112,11 @@ trait Enumerator[E] {
    * $paramEcSingle
    */
   def onDoneEnumerating(callback: => Unit)(implicit ec: ExecutionContext): Enumerator[E] = new Enumerator[E] {
-    private val pec = ec.prepare()
-
     def apply[A](it: Iteratee[E, A]): Future[Iteratee[E, A]] = parent.apply(it).andThen {
       case someTry =>
         callback
         someTry.get
-    }(pec)
+    }(ec)
 
   }
 
@@ -155,8 +153,9 @@ trait Enumerator[E] {
    * @return enumerator
    */
   def flatMap[U](f: E => Enumerator[U])(implicit ec: ExecutionContext): Enumerator[U] = {
-    val pec = ec.prepare()
+    val pec = ec
     import Execution.Implicits.{ defaultExecutionContext => ec } // Shadow ec to make this the only implicit EC in scope
+
     new Enumerator[U] {
       def apply[A](iteratee: Iteratee[U, A]): Future[Iteratee[U, A]] = {
         val folder = Iteratee.fold2[E, Iteratee[U, A]](iteratee) { (it, e) =>
@@ -366,10 +365,8 @@ object Enumerator {
    * $paramEcSingle
    */
   def unfoldM[S, E](s: S)(f: S => Future[Option[(S, E)]])(implicit ec: ExecutionContext): Enumerator[E] = checkContinue1(s)(new TreatCont1[E, S] {
-    private val pec = ec.prepare()
-
     def apply[A](loop: (Iteratee[E, A], S) => Future[Iteratee[E, A]], s: S, k: Input[E] => Iteratee[E, A]): Future[Iteratee[E, A]] = {
-      executeFuture(f(s))(pec).flatMap {
+      executeFuture(f(s))(ec).flatMap {
         case Some((newS, e)) => loop(k(Input.El(e)), newS)
         case None => Future.successful(Cont(k))
       }(dec)
@@ -394,9 +391,7 @@ object Enumerator {
    * $paramEcSingle
    */
   def unfold[S, E](s: S)(f: S => Option[(S, E)])(implicit ec: ExecutionContext): Enumerator[E] = checkContinue1(s)(new TreatCont1[E, S] {
-    private val pec = ec.prepare()
-
-    def apply[A](loop: (Iteratee[E, A], S) => Future[Iteratee[E, A]], s: S, k: Input[E] => Iteratee[E, A]): Future[Iteratee[E, A]] = Future(f(s))(pec).flatMap {
+    def apply[A](loop: (Iteratee[E, A], S) => Future[Iteratee[E, A]], s: S, k: Input[E] => Iteratee[E, A]): Future[Iteratee[E, A]] = Future(f(s))(ec).flatMap {
       case Some((s, e)) => loop(k(Input.El(e)), s)
       case None => Future.successful(Cont(k))
     }(dec)
@@ -409,10 +404,7 @@ object Enumerator {
    * $paramEcSingle
    */
   def repeat[E](e: => E)(implicit ec: ExecutionContext): Enumerator[E] = checkContinue0(new TreatCont0[E] {
-    private val pec = ec.prepare()
-
-    def apply[A](loop: Iteratee[E, A] => Future[Iteratee[E, A]], k: Input[E] => Iteratee[E, A]) = Future(e)(pec).flatMap(ee => loop(k(Input.El(ee))))(dec)
-
+    def apply[A](loop: Iteratee[E, A] => Future[Iteratee[E, A]], k: Input[E] => Iteratee[E, A]) = Future(e)(ec).flatMap(ee => loop(k(Input.El(ee))))(dec)
   })
 
   /**
@@ -422,10 +414,7 @@ object Enumerator {
    * $paramEcSingle
    */
   def repeatM[E](e: => Future[E])(implicit ec: ExecutionContext): Enumerator[E] = checkContinue0(new TreatCont0[E] {
-    private val pec = ec.prepare()
-
-    def apply[A](loop: Iteratee[E, A] => Future[Iteratee[E, A]], k: Input[E] => Iteratee[E, A]) = executeFuture(e)(pec).flatMap(ee => loop(k(Input.El(ee))))(dec)
-
+    def apply[A](loop: Iteratee[E, A] => Future[Iteratee[E, A]], k: Input[E] => Iteratee[E, A]) = executeFuture(e)(ec).flatMap(ee => loop(k(Input.El(ee))))(dec)
   })
 
   /**
@@ -436,9 +425,7 @@ object Enumerator {
    *          future eventually redeemed with None if the end of the stream has been reached.
    */
   def generateM[E](e: => Future[Option[E]])(implicit ec: ExecutionContext): Enumerator[E] = checkContinue0(new TreatCont0[E] {
-    private val pec = ec.prepare()
-
-    def apply[A](loop: Iteratee[E, A] => Future[Iteratee[E, A]], k: Input[E] => Iteratee[E, A]) = executeFuture(e)(pec).flatMap {
+    def apply[A](loop: Iteratee[E, A] => Future[Iteratee[E, A]], k: Input[E] => Iteratee[E, A]) = executeFuture(e)(ec).flatMap {
       case Some(e) => loop(k(Input.El(e)))
       case None => Future.successful(Cont(k))
     }(dec)
@@ -499,7 +486,6 @@ object Enumerator {
     onComplete: () => Unit = () => (),
     onError: (String, Input[E]) => Unit = (_: String, _: Input[E]) => ()
   )(implicit ec: ExecutionContext) = new Enumerator[E] {
-    private val pec = ec.prepare()
     def apply[A](it: Iteratee[E, A]): Future[Iteratee[E, A]] = {
 
       val iterateeP = Promise[Iteratee[E, A]]()
@@ -508,7 +494,7 @@ object Enumerator {
 
         val next = it.fold {
           case Step.Cont(k) => {
-            executeFuture(retriever(initial))(pec).map {
+            executeFuture(retriever(initial))(ec).map {
               case None => {
                 val remainingIteratee = k(Input.EOF)
                 iterateeP.success(remainingIteratee)
@@ -538,7 +524,7 @@ object Enumerator {
         next.onComplete {
           case Success(Some(i)) => step(i)
 
-          case Success(None) => Future(onComplete())(pec)
+          case Success(None) => Future(onComplete())(ec)
           case Failure(e) =>
             iterateeP.failure(e)
         }(dec)
@@ -560,7 +546,6 @@ object Enumerator {
    * @param ec The ExecutionContext to execute blocking code.
    */
   def fromStream(input: java.io.InputStream, chunkSize: Int = 1024 * 8)(implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
-    implicit val pec = ec.prepare()
     generateM({
       val buffer = new Array[Byte](chunkSize)
       val bytesRead = blocking { input.read(buffer) }
@@ -573,7 +558,7 @@ object Enumerator {
           Some(input)
       }
       Future.successful(chunk)
-    })(pec).onDoneEnumerating(input.close)(pec)
+    })(ec).onDoneEnumerating(input.close)(ec)
   }
 
   /**

--- a/iteratees/src/main/scala/play/api/libs/iteratee/RunQueue.scala
+++ b/iteratees/src/main/scala/play/api/libs/iteratee/RunQueue.scala
@@ -63,7 +63,7 @@ private[play] final class RunQueue {
    * The operation will execute in the given ExecutionContext.
    */
   def schedule[A](body: => Future[A])(implicit ec: ExecutionContext): Unit = {
-    schedule(Op(() => body.asInstanceOf[Future[Unit]], ec.prepare))
+    schedule(Op(() => body.asInstanceOf[Future[Unit]], ec))
   }
 
   /**
@@ -154,7 +154,7 @@ private object RunQueue {
    * A reified operation to be executed.
    *
    * @param thunk The logic to execute.
-   * @param ec The ExecutionContext to use for execution. Already prepared.
+   * @param ec The ExecutionContext to use for execution.
    */
   final case class Op(thunk: () => Future[Unit], ec: ExecutionContext)
 

--- a/iteratees/src/main/scala/play/api/libs/iteratee/TraversableIteratee.scala
+++ b/iteratees/src/main/scala/play/api/libs/iteratee/TraversableIteratee.scala
@@ -96,12 +96,10 @@ object Traversable {
    * $paramEcSingle
    */
   def splitOnceAt[M, E](p: E => Boolean)(implicit traversableLike: M => scala.collection.TraversableLike[E, M], ec: ExecutionContext): Enumeratee[M, M] = new CheckDone[M, M] {
-    val pec = ec.prepare()
-
     def step[A](k: K[M, A]): K[M, Iteratee[M, A]] = {
 
       case in @ Input.El(e) =>
-        Iteratee.flatten(Future(e.span(p))(pec).map {
+        Iteratee.flatten(Future(e.span(p))(ec).map {
           case (prefix, suffix) if suffix.isEmpty => new CheckDone[M, M] { def continue[A](k: K[M, A]) = Cont(step(k)) } &> k(Input.El(prefix))
           case (prefix, suffix) => Done(if (prefix.isEmpty) Cont(k) else k(Input.El(prefix)), Input.El(suffix.drop(1)))
         }(dec))

--- a/iteratees/src/main/scala/play/api/libs/iteratee/package.scala
+++ b/iteratees/src/main/scala/play/api/libs/iteratee/package.scala
@@ -51,10 +51,7 @@ package play.api.libs.iteratee {
      * def myFunc(implicit ec: ExecutionContext) = prepared(ec)(pec => ...)
      * }}}
      */
-    def prepared[A](ec: ExecutionContext)(f: ExecutionContext => A): A = {
-      val pec = ec.prepare()
-      f(pec)
-    }
+    def prepared[A](ec: ExecutionContext)(f: ExecutionContext => A): A = f(ec)
 
     val identityFunc: (Any => Any) = (x: Any) => x
   }

--- a/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
+++ b/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
@@ -111,11 +111,10 @@ object ConcurrentSpec extends Specification
           case in => throw new MatchError(in) // Shouldn't occur, but here to suppress compiler warning
         }, Duration(100, MILLISECONDS)))
         val fastEnumerator = Enumerator[Long](1, 2, 3, 4, 5, 6, 7, 8, 9, 10) >>> Enumerator.eof
-        val preparedMapEC = mapEC.prepare()
         val result =
           fastEnumerator |>>>
             (Concurrent.buffer(20) &>>
-              slowIteratee).flatMap { l => Iteratee.getChunks.map(l ++ (_: List[Long]))(preparedMapEC) }(flatMapEC)
+              slowIteratee).flatMap { l => Iteratee.getChunks.map(l ++ (_: List[Long]))(mapEC) }(flatMapEC)
 
         Await.result(result, Duration.Inf) must not equalTo (List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
         flatMapEC.executionCount must beGreaterThan(0)

--- a/iteratees/src/test/scala/play/api/libs/iteratee/ExecutionSpecification.scala
+++ b/iteratees/src/test/scala/play/api/libs/iteratee/ExecutionSpecification.scala
@@ -14,8 +14,7 @@ trait ExecutionSpecification {
 
   def testExecution[A](f: TestExecutionContext => A): A = {
     val ec = TestExecutionContext()
-    val result = ec.preparable(f(ec))
-    result
+    f(ec)
   }
 
   def testExecution[A](f: (TestExecutionContext, TestExecutionContext) => A): A = {

--- a/iteratees/src/test/scala/play/api/libs/iteratee/IterateesSpec.scala
+++ b/iteratees/src/test/scala/play/api/libs/iteratee/IterateesSpec.scala
@@ -37,8 +37,7 @@ object IterateesSpec extends Specification
   def checkFutureFoldFailure[A, E](i: Iteratee[A, E]) = {
     mustExecute(1, 1) { (foldEC, folderEC) =>
       val e = new Exception("exception")
-      val preparedFolderEC = folderEC.prepare()
-      val result = ready(i.fold(_ => Future(throw e)(preparedFolderEC))(foldEC))
+      val result = ready(i.fold(_ => Future(throw e)(folderEC))(foldEC))
       result.value must equalTo(Some(Failure(e)))
     }
   }

--- a/iteratees/src/test/scala/play/api/libs/iteratee/TestExecutionContext.scala
+++ b/iteratees/src/test/scala/play/api/libs/iteratee/TestExecutionContext.scala
@@ -20,41 +20,16 @@ object TestExecutionContext {
  * @param delegate The underlying `ExecutionContext` to delegate execution to.
  */
 class TestExecutionContext(delegate: ExecutionContext) extends ExecutionContext {
-  top =>
 
   val count = new java.util.concurrent.atomic.AtomicInteger()
 
-  val local = new ThreadLocal[java.lang.Boolean]
-
-  def preparable[A](body: => A): A = {
-    local.set(true)
-    try body finally local.set(null)
-  }
-
   def execute(runnable: Runnable): Unit = {
-    throw new RuntimeException("Cannot execute unprepared TestExecutionContext")
+    count.getAndIncrement()
+    delegate.execute(runnable)
   }
 
   def reportFailure(t: Throwable): Unit = {
     println(t)
-  }
-
-  override def prepare(): ExecutionContext = {
-    val isLocal = Option(local.get()).getOrElse(false: java.lang.Boolean)
-    if (!isLocal) throw new RuntimeException("Can only prepare TestExecutionContext within 'preparable' scope")
-    val preparedDelegate = delegate.prepare()
-    return new ExecutionContext {
-
-      def execute(runnable: Runnable): Unit = {
-        count.getAndIncrement()
-        preparedDelegate.execute(runnable)
-      }
-
-      def reportFailure(t: Throwable): Unit = {
-        println(t)
-      }
-
-    }
   }
 
   def executionCount: Int = count.get()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 
-addSbtPlugin("com.typesafe.play" % "interplay" % "1.3.5")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.8")
+addSbtPlugin("com.typesafe.play" % "interplay" % "1.3.18")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
 

--- a/streams/src/main/scala/play/api/libs/iteratee/streams/IterateeStreams.scala
+++ b/streams/src/main/scala/play/api/libs/iteratee/streams/IterateeStreams.scala
@@ -113,7 +113,7 @@ object IterateeStreams {
    * by iterateeDoneToPublisher to extract the value of a Done iteratee.
    */
   private def iterateeFoldToPublisher[T, U, V](iter: Iteratee[T, U], f: Step[T, U] => Future[V])(implicit ec: ExecutionContext): Publisher[V] = {
-    val fut: Future[V] = iter.fold(f)(ec.prepare)
+    val fut: Future[V] = iter.fold(f)(ec)
     val pubr: Publisher[V] = futureToPublisher(fut)
     pubr
   }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [ ] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes https://github.com/playframework/play-iteratees/issues/21

## Purpose

What does this PR do?

Removes the use of ExecutionContext#prepare

## Background Context

Why did you take this approach?

Trying to remove deprecated functions.

Pre-supposes https://github.com/playframework/play-iteratees/pull/23 will be merged. If that PR is a problem, I can rework this PR.

## References

Are there any relevant issues / PRs / mailing lists discussions?

https://github.com/playframework/play-iteratees/issues/21